### PR TITLE
Use the shortDescription for the background

### DIFF
--- a/src/convert.ts
+++ b/src/convert.ts
@@ -537,7 +537,7 @@ const getTextBlocks = (ddbCharacter: DdbCharacter): AlchemyTextBlockSection[] =>
     title: "Background",
     textBlocks: [{
       title: ddbCharacter.background.definition.name,
-      body: turndownService.turndown(ddbCharacter.background.definition.description),
+      body: turndownService.turndown(ddbCharacter.background.definition.shortDescription),
     }]
   })
 

--- a/src/ddb.ts
+++ b/src/ddb.ts
@@ -292,6 +292,7 @@ interface DdbBackground {
   definition: {
     name: string,
     description: string,
+    shortDescription: string,
   }
 }
 


### PR DESCRIPTION
Reported by Arcadys — it's probably not useful (and even confusing)
to show the entire background, including its roll tables, in
Alchemy. Instead we can just use the shortDescription.
