### PR TITLE
Bundle turndown dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "private": true,
   "dependencies": {
     "esbuild": "^0.15.16",
+    "turndown": "^7.1.1",
     "turndown-plugin-gfm": "1.0.2",
     "typescript": "^4.9.3"
   },
@@ -14,5 +15,8 @@
     "build": "esbuild src/index.ts --outfile=public/index.min.js --bundle --minify --sourcemap",
     "start": "esbuild src/index.ts --outfile=public/index.min.js --bundle --sourcemap --servedir=public",
     "lint": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/turndown": "^5.0.1"
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,6 @@
 
 <head>
   <title>D&D Beyond to Alchemy Converter</title>
-  <script src="https://unpkg.com/turndown/dist/turndown.js"></script>
   <script src="index.min.js"></script>
   <link rel="stylesheet" href="style.css">
   <link rel="shortcut icon" type="image/x-icon" href="favicon.png">

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -1,5 +1,6 @@
 import { DdbArmorType, DdbModifier, DdbCharacter, DdbProficiencyType, DdbSpell, DdbSpellActivationType, DDB_SPEED_RE, DDB_SPELL_ACTIVATION_TYPE, DDB_SPELL_COMPONENT_TYPE } from "./ddb"
 import { AlchemyCharacter, AlchemyStat, AlchemyClass, AlchemyProficiency, AlchemyMovementMode, AlchemyTextBlockSection, AlchemySkill, AlchemyItem, AlchemySpellSlot, AlchemySpell, AlchemyDamage, AlchemySpellAtHigherLevel } from "./alchemy"
+import TurndownService from 'turndown'
 import * as turndownPluginGfm from 'turndown-plugin-gfm'
 
 // Shared between both platforms

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,1 +1,0 @@
-declare const TurndownService: any;

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,6 +12,16 @@
   resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.15.16.tgz#284522de76abe951e4ed2bd24a467e8d49c67933"
   integrity sha512-SDLfP1uoB0HZ14CdVYgagllgrG7Mdxhkt4jDJOKl/MldKrkQ6vDJMZKl2+5XsEY/Lzz37fjgLQoJBGuAw/x8kQ==
 
+"@types/turndown@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@types/turndown/-/turndown-5.0.1.tgz#fcda7b02cda4c9d445be1440036df20f335b9387"
+  integrity sha512-N8Ad4e3oJxh9n9BiZx9cbe/0M3kqDpOTm2wzj13wdDUxDPjfjloWIJaquZzWE1cYTAHpjOH3rcTnXQdpEfS/SQ==
+
+domino@^2.1.6:
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/domino/-/domino-2.1.6.tgz#fe4ace4310526e5e7b9d12c7de01b7f485a57ffe"
+  integrity sha512-3VdM/SXBZX2omc9JF9nOPCtDaYQ67BGp5CoLpIQlO2KCAPETs8TcDHacF26jXadGbvUteZzRTeos2fhID5+ucQ==
+
 esbuild-android-64@0.15.16:
   version "0.15.16"
   resolved "https://registry.yarnpkg.com/esbuild-android-64/-/esbuild-android-64-0.15.16.tgz#0d6a16fa1bea441d5183976f1633183c25a764d5"
@@ -144,6 +154,13 @@ turndown-plugin-gfm@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/turndown-plugin-gfm/-/turndown-plugin-gfm-1.0.2.tgz#6f8678a361f35220b2bdf5619e6049add75bf1c7"
   integrity sha512-vwz9tfvF7XN/jE0dGoBei3FXWuvll78ohzCZQuOb+ZjWrs3a0XhQVomJEb2Qh4VHTPNRO4GPZh0V7VRbiWwkRg==
+
+turndown@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/turndown/-/turndown-7.1.1.tgz#96992f2d9b40a1a03d3ea61ad31b5a5c751ef77f"
+  integrity sha512-BEkXaWH7Wh7e9bd2QumhfAXk5g34+6QUmmWx+0q6ThaVOLuLUqsnkq35HQ5SBHSaxjSfSM7US5o4lhJNH7B9MA==
+  dependencies:
+    domino "^2.1.6"
 
 typescript@^4.9.3:
   version "4.9.3"


### PR DESCRIPTION
This lets us point at a particular turndown version, and avoids
an API call from within Alchemy. The bundle is still only about
22kb, which seems reasonable.
